### PR TITLE
Remove unnecessary permission changes, add pre judgment for root uid.

### DIFF
--- a/install-dat-release.sh
+++ b/install-dat-release.sh
@@ -65,7 +65,7 @@ download_geosite() {
 
 rename_new() {
     for DAT in 'geoip' 'geosite'; do
-        install "${V2RAY}$DAT.dat.new" "${V2RAY}$DAT.dat"
+        install -m 644 "${V2RAY}$DAT.dat.new" "${V2RAY}$DAT.dat"
         rm "${V2RAY}$DAT.dat.new"
         rm "${V2RAY}$DAT.dat.sha256sum.new"
     done

--- a/install-dat-release.sh
+++ b/install-dat-release.sh
@@ -18,6 +18,7 @@ DOWNLOAD_LINK_GEOIP="https://github.com/v2ray/geoip/releases/latest/download/geo
 DOWNLOAD_LINK_GEOSITE="https://github.com/v2ray/domain-list-community/releases/latest/download/dlc.dat"
 
 check_if_running_as_root() {
+    # If you want to run as another user, please modify $UID to be owned by this user
     if [ $UID != "0" ]; then
         echo "error: You must run this script as root!"
         exit 1

--- a/install-dat-release.sh
+++ b/install-dat-release.sh
@@ -57,7 +57,7 @@ download_geosite() {
 
 rename_new() {
     for DAT in 'geoip' 'geosite'; do
-        install -m 755 "${V2RAY}$DAT.dat.new" "${V2RAY}$DAT.dat"
+        install "${V2RAY}$DAT.dat.new" "${V2RAY}$DAT.dat"
         rm "${V2RAY}$DAT.dat.new"
         rm "${V2RAY}$DAT.dat.sha256sum.new"
     done

--- a/install-dat-release.sh
+++ b/install-dat-release.sh
@@ -17,6 +17,13 @@ V2RAY="/usr/local/lib/v2ray/"
 DOWNLOAD_LINK_GEOIP="https://github.com/v2ray/geoip/releases/latest/download/geoip.dat"
 DOWNLOAD_LINK_GEOSITE="https://github.com/v2ray/domain-list-community/releases/latest/download/dlc.dat"
 
+check_if_running_as_root() {
+    if [ $UID != "0" ]; then
+        echo "error: You must run this script as root!"
+        exit 1
+    fi
+}
+
 download_geoip() {
     curl -L -H 'Cache-Control: no-cache' -o "${V2RAY}geoip.dat.new" "$DOWNLOAD_LINK_GEOIP"
     if [ "$?" -ne '0' ]; then
@@ -64,6 +71,7 @@ rename_new() {
 }
 
 main() {
+    check_if_running_as_root
     download_geoip
     download_geosite
     rename_new

--- a/install-release.sh
+++ b/install-release.sh
@@ -13,6 +13,7 @@
 # https://github.com/v2fly/fhs-install-v2ray/issues
 
 check_if_running_as_root() {
+    # If you want to run as another user, please modify $UID to be owned by this user
     if [ $UID != "0" ]; then
         echo "error: You must run this script as root!"
         exit 1

--- a/install-release.sh
+++ b/install-release.sh
@@ -12,6 +12,13 @@
 # If the script executes incorrectly, go to:
 # https://github.com/v2fly/fhs-install-v2ray/issues
 
+check_if_running_as_root() {
+    if [ $UID != "0" ]; then
+        echo "error: You must run this script as root!"
+        exit 1
+    fi
+}
+
 identify_the_operating_system_and_architecture() {
     if [[ "$(uname)" == 'Linux' ]]; then
         case "$(uname -m)" in
@@ -459,6 +466,7 @@ show_help() {
 }
 
 main() {
+    check_if_running_as_root
     identify_the_operating_system_and_architecture
     judgment_parameters "$@"
 

--- a/install-release.sh
+++ b/install-release.sh
@@ -330,7 +330,7 @@ install_file() {
     if [[ "$NAME" == 'v2ray' ]] || [[ "$NAME" == 'v2ctl' ]]; then
         install -m 755 "${TMP_DIRECTORY}$NAME" "/usr/local/bin/$NAME"
     elif [[ "$NAME" == 'geoip.dat' ]] || [[ "$NAME" == 'geosite.dat' ]]; then
-        install "${TMP_DIRECTORY}$NAME" "/usr/local/lib/v2ray/$NAME"
+        install -m 644 "${TMP_DIRECTORY}$NAME" "/usr/local/lib/v2ray/$NAME"
     fi
 }
 
@@ -376,8 +376,8 @@ install_startup_service_file() {
             echo 'error: Failed to start service file download! Please check your network or try again.'
             exit 1
         fi
-        install "${TMP_DIRECTORY}systemd/system/v2ray.service" /etc/systemd/system/v2ray.service
-        install "${TMP_DIRECTORY}systemd/system/v2ray@.service" /etc/systemd/system/v2ray@.service
+        install -m 644 "${TMP_DIRECTORY}systemd/system/v2ray.service" /etc/systemd/system/v2ray.service
+        install -m 644 "${TMP_DIRECTORY}systemd/system/v2ray@.service" /etc/systemd/system/v2ray@.service
         SYSTEMD='1'
     fi
 }

--- a/install-release.sh
+++ b/install-release.sh
@@ -322,7 +322,7 @@ install_file() {
     if [[ "$NAME" == 'v2ray' ]] || [[ "$NAME" == 'v2ctl' ]]; then
         install -m 755 "${TMP_DIRECTORY}$NAME" "/usr/local/bin/$NAME"
     elif [[ "$NAME" == 'geoip.dat' ]] || [[ "$NAME" == 'geosite.dat' ]]; then
-        install -m 755 "${TMP_DIRECTORY}$NAME" "/usr/local/lib/v2ray/$NAME"
+        install "${TMP_DIRECTORY}$NAME" "/usr/local/lib/v2ray/$NAME"
     fi
 }
 
@@ -368,8 +368,8 @@ install_startup_service_file() {
             echo 'error: Failed to start service file download! Please check your network or try again.'
             exit 1
         fi
-        install -m 755 "${TMP_DIRECTORY}systemd/system/v2ray.service" /etc/systemd/system/v2ray.service
-        install -m 755 "${TMP_DIRECTORY}systemd/system/v2ray@.service" /etc/systemd/system/v2ray@.service
+        install "${TMP_DIRECTORY}systemd/system/v2ray.service" /etc/systemd/system/v2ray.service
+        install "${TMP_DIRECTORY}systemd/system/v2ray@.service" /etc/systemd/system/v2ray@.service
         SYSTEMD='1'
     fi
 }


### PR DESCRIPTION
我参考了原V2ray项目下的自动安装脚本[install-release.sh](https://github.com/v2ray/v2ray-core/blob/master/release/install-release.sh)和[updatedat.sh](https://github.com/v2ray/v2ray-core/blob/master/release/updatedat.sh)，其并没有对除v2ray和v2ctl两个二进制可执行文件以外的安装文件进行更改权限的操作，所以我认为，安装时和安装后对包括v2ray.service和geosite.dat等文件赋予可执行权限是没有必要的。