### PR TITLE
fix: Incorrect execution of stop_v2ray function

### DIFF
--- a/install-release.sh
+++ b/install-release.sh
@@ -513,9 +513,11 @@ main() {
     fi
 
     # Determine if V2Ray is running
-    if [[ -n "$(pgrep v2ray)" ]]; then
-        stop_v2ray
-        V2RAY_RUNNING='1'
+    if [[ -n "$(systemctl list-unit-files | grep 'v2ray')" ]]; then
+        if [[ -n "$(pgrep v2ray)" ]]; then
+            stop_v2ray
+            V2RAY_RUNNING='1'
+        fi
     fi
     install_v2ray
     install_startup_service_file


### PR DESCRIPTION
1. In the first installation, if there happens to be a V2Ray service that is not managed by systemd, or if there is a judgment error, the stop_v2ray function will be executed incorrectly, which will cause the installation to fail.

issue #29