### PR TITLE
Fix issue #33

### DIFF
--- a/install-release.sh
+++ b/install-release.sh
@@ -244,7 +244,7 @@ get_version() {
         # Get V2Ray release version number
         TMP_FILE="$(mktemp)"
         install_software curl
-        if ! curl ${PROXY} -s -o "$TMP_FILE" 'https://api.github.com/repos/v2fly/v2ray-core/releases/latest'; then
+        if ! curl "${PROXY}" -s -o "$TMP_FILE" 'https://api.github.com/repos/v2fly/v2ray-core/releases/latest'; then
             rm "$TMP_FILE"
             echo 'error: Failed to get release list, please check your network.'
             exit 1
@@ -292,12 +292,12 @@ download_v2ray() {
     mkdir "$TMP_DIRECTORY"
     DOWNLOAD_LINK="https://github.com/v2fly/v2ray-core/releases/download/$RELEASE_VERSION/v2ray-linux-$MACHINE.zip"
     echo "Downloading V2Ray archive: $DOWNLOAD_LINK"
-    if ! curl ${PROXY} -L -H 'Cache-Control: no-cache' -o "$ZIP_FILE" "$DOWNLOAD_LINK"; then
+    if ! curl "${PROXY}" -L -H 'Cache-Control: no-cache' -o "$ZIP_FILE" "$DOWNLOAD_LINK"; then
         echo 'error: Download failed! Please check your network or try again.'
         return 1
     fi
     echo "Downloading verification file for V2Ray archive: $DOWNLOAD_LINK.dgst"
-    if ! curl ${PROXY} -L -H 'Cache-Control: no-cache' -o "$ZIP_FILE.dgst" "$DOWNLOAD_LINK.dgst"; then
+    if ! curl "${PROXY}" -L -H 'Cache-Control: no-cache' -o "$ZIP_FILE.dgst" "$DOWNLOAD_LINK.dgst"; then
         echo 'error: Download failed! Please check your network or try again.'
         return 1
     fi
@@ -371,11 +371,11 @@ install_startup_service_file() {
     if [[ ! -f '/etc/systemd/system/v2ray.service' ]]; then
         mkdir "${TMP_DIRECTORY}systemd/system/"
         install_software curl
-        if ! curl ${PROXY} -s -o "${TMP_DIRECTORY}systemd/system/v2ray.service" 'https://raw.githubusercontent.workers.dev/v2fly/fhs-install-v2ray/master/systemd/system/v2ray.service'; then
+        if ! curl "${PROXY}" -s -o "${TMP_DIRECTORY}systemd/system/v2ray.service" 'https://raw.githubusercontent.workers.dev/v2fly/fhs-install-v2ray/master/systemd/system/v2ray.service'; then
             echo 'error: Failed to start service file download! Please check your network or try again.'
             exit 1
         fi
-        if ! curl ${PROXY} -s -o "${TMP_DIRECTORY}systemd/system/v2ray@.service" 'https://raw.githubusercontent.workers.dev/v2fly/fhs-install-v2ray/master/systemd/system/v2ray@.service'; then
+        if ! curl "${PROXY}" -s -o "${TMP_DIRECTORY}systemd/system/v2ray@.service" 'https://raw.githubusercontent.workers.dev/v2fly/fhs-install-v2ray/master/systemd/system/v2ray@.service'; then
             echo 'error: Failed to start service file download! Please check your network or try again.'
             exit 1
         fi

--- a/install-release.sh
+++ b/install-release.sh
@@ -29,14 +29,20 @@ identify_the_operating_system_and_architecture() {
             'amd64' | 'x86_64')
                 MACHINE='64'
                 ;;
-            'armv6l' | 'armv7' | 'armv7l' )
-                MACHINE='arm'
+            'armv5tel')
+                MACHINE='arm32-v5'
+                ;;
+            'armv6l')
+                MACHINE='arm32-v6'
+                ;;
+            'armv7' | 'armv7l' )
+                MACHINE='arm32-v7a'
                 ;;
             'armv8' | 'aarch64')
-                MACHINE='arm64'
+                MACHINE='arm64-v8a'
                 ;;
             'mips')
-                MACHINE='mips'
+                MACHINE='mips32'
                 ;;
             'mips64')
                 MACHINE='mips64'
@@ -45,7 +51,7 @@ identify_the_operating_system_and_architecture() {
                 MACHINE='mips64le'
                 ;;
             'mipsle')
-                MACHINE='mipsle'
+                MACHINE='mips32le'
                 ;;
             's390x')
                 MACHINE='s390x'


### PR DESCRIPTION
我手上没有 armv5 的设备，Google `linux "armv5" "uname"` 找到了一个 `uname -m` 的输出 `armv5tel`，这也出现在 fedora 的发行历史页上，所以我判定选择这个是安全的。
欢迎补充我遗漏的架构名。