### PR TITLE
显示下载V2Ray archive进度

### DIFF
--- a/install-release.sh
+++ b/install-release.sh
@@ -254,7 +254,7 @@ get_version() {
 download_v2ray() {
   DOWNLOAD_LINK="https://github.com/v2fly/v2ray-core/releases/download/$RELEASE_VERSION/v2ray-linux-$MACHINE.zip"
   echo "Downloading V2Ray archive: $DOWNLOAD_LINK"
-  if ! "curl" ${PROXY} -sSLR -H "Accept: application/vnd.github.v3+json" -H 'Cache-Control: no-cache' -o "$ZIP_FILE" "$DOWNLOAD_LINK"; then
+  if ! "curl" ${PROXY} -SLRO -H "Accept: application/vnd.github.v3+json" -H 'Cache-Control: no-cache' -o "$ZIP_FILE" "$DOWNLOAD_LINK"; then
     echo 'error: Download failed! Please check your network or try again.'
     return 1
   fi


### PR DESCRIPTION
在天朝Github的下载速度非常慢，通常只有几k。之前脚本通过`-s`屏蔽curl的输出，造成程序好像卡在`Downloading V2Ray archive`步骤的假象。去除屏蔽之后可让用户了解下载进度，体验更加理想。

```
info: Installing V2Ray v4.28.2 for x86_64
Downloading V2Ray archive: https://github.com/v2fly/v2ray-core/releases/download/v4.28.2/v2ray-linux-64.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   644  100   644    0     0    112      0  0:00:05  0:00:05 --:--:--   153
 55 11.5M   55 6561k    0     0  12902      0  0:15:38  0:08:40  0:06:58 16296
```