### PR TITLE
delete `--false-start --http2 --tlsv1.2`

### DIFF
--- a/install-release.sh
+++ b/install-release.sh
@@ -28,7 +28,7 @@ green=$(tput setaf 2)
 reset=$(tput sgr0)
 
 curl() {
-    $(type -P curl) -L -q -# --retry 5 --retry-delay 10 --retry-max-time 60 --false-start --http2 --tlsv1.2 "$@"
+    $(type -P curl) -L -q --retry 5 --retry-delay 10 --retry-max-time 60 --false-start --http2 --tlsv1.2 "$@"
 }
 
 check_if_running_as_root() {

--- a/install-release.sh
+++ b/install-release.sh
@@ -27,7 +27,9 @@ red=$(tput setaf 1)
 green=$(tput setaf 2)
 reset=$(tput sgr0)
 
-alias curl='"curl" --retry 5 --retry-delay 10 --retry-max-time 60 --false-start --http2 --tlsv1.2 -L'
+curl() {
+    $(type -P curl) -L -q -# --retry 5 --retry-delay 10 --retry-max-time 60 --false-start --http2 --tlsv1.2 "$@"
+}
 
 check_if_running_as_root() {
   # If you want to run as another user, please modify $UID to be owned by this user


### PR DESCRIPTION
Try to fix #132.
> `-q`: Disable .curlrc
> `-L`: Follow redirects
> `--false-start`: Enable TLS False Start
> `--http2`: Use HTTP 2
> `--tlsv1.2`: Use TLSv1.2 or greater