### PR TITLE
Revert "Add root uid judgment before running"

### DIFF
--- a/install-dat-release.sh
+++ b/install-dat-release.sh
@@ -26,14 +26,6 @@ curl() {
   $(type -P curl) -L -q --retry 5 --retry-delay 10 --retry-max-time 60 "$@"
 }
 
-check_if_running_as_root() {
-  # If you want to run as another user, please modify $UID to be owned by this user
-  if [[ "$UID" -ne '0' ]]; then
-    echo "error: You must run this script as root!"
-    exit 1
-  fi
-}
-
 download_files() {
   if ! curl -R -H 'Cache-Control: no-cache' -o "${dir_tmp}/${2}" "${1}"; then
     echo 'error: Download failed! Please check your network or try again.'
@@ -64,7 +56,6 @@ install_file() {
 }
 
 main() {
-  check_if_running_as_root
   download_files $DOWNLOAD_LINK_GEOIP $file_ip
   download_files $DOWNLOAD_LINK_GEOSITE $file_dlc
   check_sum

--- a/install-release.sh
+++ b/install-release.sh
@@ -44,14 +44,6 @@ systemd_cat_config() {
   fi
 }
 
-check_if_running_as_root() {
-  # If you want to run as another user, please modify $UID to be owned by this user
-  if [[ "$UID" -ne '0' ]]; then
-    echo "error: You must run this script as root!"
-    exit 1
-  fi
-}
-
 identify_the_operating_system_and_architecture() {
   if [[ "$(uname)" == 'Linux' ]]; then
     case "$(uname -m)" in
@@ -499,7 +491,6 @@ show_help() {
 }
 
 main() {
-  check_if_running_as_root
   identify_the_operating_system_and_architecture
   judgment_parameters "$@"
 


### PR DESCRIPTION
仔细想想不需要登陆 root 便能使用两个脚本的情况挺多的，比如一些路由器固件使用路由器管理页面管理员登录名作用户名且拥有读写这些位置的权限。
也许脚本需要一个权限检查，但 `"$UID" -ne '0'` 不一定是最好的选择。
~~其实早就想撤回这条提交了，但因为是自己提交的感觉有点尴尬~~