### PR TITLE
Check GitHub API status code

### DIFF
--- a/install-release.sh
+++ b/install-release.sh
@@ -248,8 +248,8 @@ get_version() {
     echo 'error: Failed to get release list, please check your network.'
     exit 1
   fi
-  HTTP_STATUS_CODE="$(awk 'NR==1 {print $2}' "$TMP_FILE")"
-  if [ "$HTTP_STATUS_CODE" != "200" ]; then
+  HTTP_STATUS_CODE=$(awk 'NR==1 {print $2}' "$TMP_FILE")
+  if [[ "$HTTP_STATUS_CODE" -ge 200 ]] || [[ "$HTTP_STATUS_CODE" -le 299 ]]; then
     "rm" "$TMP_FILE"
     echo "error: Failed to get release list, GitHub API response code: $HTTP_STATUS_CODE"
     exit 1

--- a/install-release.sh
+++ b/install-release.sh
@@ -250,9 +250,9 @@ get_version() {
   fi
   HTTP_STATUS_CODE="$(awk 'NR==1 {print $2}' "$TMP_FILE")"
   if [ "$HTTP_STATUS_CODE" != "200" ]; then
-	  "rm" "$TMP_FILE"
-	  echo "error: Failed to get release list, GitHub API response code: $HTTP_STATUS_CODE"
-	  exit 1
+    "rm" "$TMP_FILE"
+    echo "error: Failed to get release list, GitHub API response code: $HTTP_STATUS_CODE"
+    exit 1
   fi
   RELEASE_LATEST="$(sed 'y/,/\n/' "$TMP_FILE" | grep 'tag_name' | awk -F '"' '{print $4}')"
   "rm" "$TMP_FILE"

--- a/install-release.sh
+++ b/install-release.sh
@@ -243,10 +243,16 @@ get_version() {
   fi
   # Get V2Ray release version number
   TMP_FILE="$(mktemp)"
-  if ! curl -x "${PROXY}" -sS -H "Accept: application/vnd.github.v3+json" -o "$TMP_FILE" 'https://api.github.com/repos/v2fly/v2ray-core/releases/latest'; then
+  if ! curl -x "${PROXY}" -sS -i -H "Accept: application/vnd.github.v3+json" -o "$TMP_FILE" 'https://api.github.com/repos/v2fly/v2ray-core/releases/latest'; then
     "rm" "$TMP_FILE"
     echo 'error: Failed to get release list, please check your network.'
     exit 1
+  fi
+  HTTP_STATUS_CODE="$(awk 'NR==1 {print $2}' "$TMP_FILE")"
+  if [ "$HTTP_STATUS_CODE" != "200" ]; then
+	  "rm" "$TMP_FILE"
+	  echo "error: Failed to get release list, GitHub API response code: $HTTP_STATUS_CODE"
+	  exit 1
   fi
   RELEASE_LATEST="$(sed 'y/,/\n/' "$TMP_FILE" | grep 'tag_name' | awk -F '"' '{print $4}')"
   "rm" "$TMP_FILE"

--- a/install-release.sh
+++ b/install-release.sh
@@ -249,7 +249,7 @@ get_version() {
     exit 1
   fi
   HTTP_STATUS_CODE=$(awk 'NR==1 {print $2}' "$TMP_FILE")
-  if [[ "$HTTP_STATUS_CODE" -ge 200 ]] || [[ "$HTTP_STATUS_CODE" -le 299 ]]; then
+  if [[ $HTTP_STATUS_CODE -lt 200 ]] || [[ $HTTP_STATUS_CODE -gt 299 ]]; then
     "rm" "$TMP_FILE"
     echo "error: Failed to get release list, GitHub API response code: $HTTP_STATUS_CODE"
     exit 1


### PR DESCRIPTION
In old version when GitHub API returns 403 due to Rate limit, script continues to run and results in undefined behavior:
`info: No new version. The current version of V2Ray is  .`